### PR TITLE
Make file reading thread-safe, by having SubFile use read_at/seek_read rather than seek and read.

### DIFF
--- a/src/data/iterators.rs
+++ b/src/data/iterators.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, fs::File};
+use std::fmt::Display;
 
 use chrono::{DateTime, NaiveDate, Utc};
 
@@ -241,14 +241,11 @@ impl Iterator for Vectors {
 #[derive(Debug)]
 pub struct GenericBoundaries<T: NumberType> {
     value: BoundaryValues<T>,
-    inclusive: SimpleIter<bool, SubFile<File>>,
+    inclusive: SimpleIter<bool, SubFile>,
 }
 
 impl<T: NumberType> GenericBoundaries<T> {
-    pub fn new(
-        value: SimpleIter<T, SubFile<File>>,
-        inclusive: SimpleIter<bool, SubFile<File>>,
-    ) -> Self {
+    pub fn new(value: SimpleIter<T, SubFile>, inclusive: SimpleIter<bool, SubFile>) -> Self {
         Self {
             value: BoundaryValues::new(value),
             inclusive,

--- a/src/file/parquet/reader.rs
+++ b/src/file/parquet/reader.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-
 use crate::{
     array_type,
     data::*,
@@ -12,10 +10,7 @@ use crate::{
 use super::{super::Reader, schemas};
 
 impl Reader {
-    fn array_reader(
-        &self,
-        array: &Array<impl ArrayType>,
-    ) -> Result<PqArrayReader<SubFile<File>>, Error> {
+    fn array_reader(&self, array: &Array<impl ArrayType>) -> Result<PqArrayReader<SubFile>, Error> {
         let f = self.array_bytes_reader(array)?;
         let reader = PqArrayReader::new(f)?;
         if array.item_count() != reader.len() {

--- a/src/file/parquet/schemas.rs
+++ b/src/file/parquet/schemas.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, sync::OnceLock};
+use std::sync::OnceLock;
 
 use crate::{
     file::SubFile,
@@ -23,7 +23,7 @@ macro_rules! declare_schema {
             }
 
             pub fn check(
-                reader: &PqArrayReader<SubFile<File>>,
+                reader: &PqArrayReader<SubFile>,
             ) -> Result<$name, crate::error::Error> {
                 reader.matches(Self::matcher())
             }

--- a/src/file/reader.rs
+++ b/src/file/reader.rs
@@ -86,7 +86,6 @@ impl Default for Limits {
 /// > where data is maliciously crafted to expand to an excessive size when decompressed,
 /// > leading to a potential denial of service attack.
 /// > Use the limits provided check arrays sizes before allocating memory.
-
 pub struct Reader {
     archive: Archive,
     version: [u32; 2],
@@ -175,7 +174,7 @@ impl Reader {
     pub fn array_bytes_reader(
         &self,
         array: &array::Array<impl array::ArrayType>,
-    ) -> Result<SubFile<File>, Error> {
+    ) -> Result<SubFile, Error> {
         array.constraint(); // Check that validation has been done.
         self.archive.open(array.filename())
     }

--- a/src/file/sub_file.rs
+++ b/src/file/sub_file.rs
@@ -1,67 +1,78 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    sync::Arc,
+};
 
 /// A seek-able sub-file with a start and end point within a larger file.
-pub struct SubFile<T> {
-    inner: T,
-    offset: u64,
+pub struct SubFile {
+    inner: Arc<File>,
+    /// Start of the sub-file within `inner`.
+    start: u64,
+    /// The current file cursor position within the sub-file.
     position: u64,
-    limit: u64,
+    /// The length of the sub-file in bytes.
+    len: u64,
 }
 
-impl<T: Seek> SubFile<T> {
+impl SubFile {
     /// Creates a sub-file from seek-able object.
     ///
     /// This new file will its start and zero position at the current position of `inner` and
-    /// extend up to `limit` bytes.
-    pub fn new(mut inner: T, limit: u64) -> std::io::Result<Self> {
+    /// extend up to `len` bytes.
+    pub fn new(inner: Arc<File>, start: u64, len: u64) -> std::io::Result<Self> {
+        start
+            .checked_add(len)
+            .expect("start + len should not overflow");
         Ok(Self {
-            position: 0,
-            offset: inner.stream_position()?,
+            start,
             inner,
-            limit,
+            position: 0,
+            len,
         })
     }
 
     /// Returns the total length of the sub-file, ignoring the current position.
     pub fn len(&self) -> u64 {
-        self.limit
+        self.len
     }
 
     /// Returns true if the file is empty.
     pub fn is_empty(&self) -> bool {
-        self.limit == 0
+        self.len == 0
+    }
+
+    /// Returns the number of bytes remaining in the sub-file.
+    fn remaining(&self) -> u64 {
+        self.len.saturating_sub(self.position)
     }
 }
 
-impl<T: Read> Read for SubFile<T> {
+impl Read for SubFile {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.position == self.limit {
+        if self.position >= self.len {
             return Ok(0);
         }
-        let max = (buf.len() as u64).min(self.limit - self.position) as usize;
-        let n = self.inner.read(&mut buf[..max])?;
-        assert!(
-            self.position + (n as u64) <= self.limit,
-            "number of read bytes exceeds limit"
-        );
+        let limit = usize::try_from((buf.len() as u64).min(self.remaining())).expect("valid limit");
+        let n = read_at(
+            self.inner.as_ref(),
+            &mut buf[..limit],
+            self.start + self.position,
+        )?;
         self.position += n as u64;
         Ok(n)
     }
 }
 
-impl<T: Seek> Seek for SubFile<T> {
+impl Seek for SubFile {
     fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
         let new_position = match pos {
             SeekFrom::Start(pos) => pos as i64,
-            SeekFrom::End(delta) => self.limit as i64 + delta,
-            SeekFrom::Current(delta) => self.position as i64 + delta,
+            SeekFrom::End(delta) => (self.len as i64).saturating_add(delta),
+            SeekFrom::Current(delta) => (self.position as i64).saturating_add(delta),
         };
-        if new_position < 0 {
-            return Err(std::io::ErrorKind::InvalidInput.into());
-        }
-        self.position = new_position as u64;
-        self.inner
-            .seek(SeekFrom::Start(self.offset + self.position))?;
+        self.position =
+            u64::try_from(new_position).map_err(|_| std::io::ErrorKind::InvalidInput)?;
         Ok(self.position)
     }
 
@@ -71,38 +82,55 @@ impl<T: Seek> Seek for SubFile<T> {
 }
 
 #[cfg(feature = "parquet")]
-impl parquet::file::reader::Length for SubFile<std::fs::File> {
+impl parquet::file::reader::Length for SubFile {
     fn len(&self) -> u64 {
-        self.limit
+        self.len
     }
 }
 
 #[cfg(feature = "parquet")]
-impl parquet::file::reader::ChunkReader for SubFile<std::fs::File> {
+impl parquet::file::reader::ChunkReader for SubFile {
     type T = <std::fs::File as parquet::file::reader::ChunkReader>::T;
 
     fn get_read(&self, start: u64) -> parquet::errors::Result<Self::T> {
-        self.inner.get_read(self.offset.saturating_add(start))
+        self.inner.get_read(self.start.saturating_add(start))
     }
 
     fn get_bytes(&self, start: u64, length: usize) -> parquet::errors::Result<bytes::Bytes> {
         self.inner
-            .get_bytes(self.offset.saturating_add(start), length)
+            .get_bytes(self.start.saturating_add(start), length)
     }
+}
+
+/// Reads from a file at a specific offset
+///
+/// The Windows implementation moves the file cursor, which the Unix one doesn't,
+/// so this should only be used from code that doesn't care about the file cursor.
+#[cfg(windows)]
+fn read_at(file: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    use std::os::windows::fs::FileExt;
+    file.seek_read(buf, offset)
+}
+
+/// Reads from a file at a specific offset
+#[cfg(unix)]
+fn read_at(file: &std::fs::File, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+    use std::os::unix::fs::FileExt;
+    file.read_at(buf, offset)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
+    use std::path::Path;
 
     use super::*;
 
     #[test]
     fn subfile() {
-        let data = b"0123456789";
-        let mut base = Cursor::new(data);
-        base.seek(SeekFrom::Start(2)).unwrap();
-        let mut t = SubFile::new(base, 6).unwrap();
+        let path = Path::new("./target/tmp/subfile.txt");
+        std::fs::write(path, b"0123456789").unwrap();
+        let base = Arc::new(File::open(path).unwrap());
+        let mut t = SubFile::new(base.clone(), 2, 6).unwrap();
         let mut buf = [0; 5];
         t.read_exact(&mut buf).unwrap();
         assert_eq!(&buf, b"23456");


### PR DESCRIPTION
This fixes the bug of assuming `try_clone` duplicates the file descriptor, and instead uses an `Arc<File>` with seeking reads directly.