### PR TITLE
Fixed windows script for building docs.

### DIFF
--- a/docs/build.bat
+++ b/docs/build.bat
@@ -4,5 +4,5 @@ cd ..
 cargo test -p omf --lib -- --ignored update_schema_docs || exit /b
 cargo doc --no-deps || exit /b
 python -m mkdocs build || exit /b
-mv ./target/doc ./site/rust || exit /b
-rm ./site/rust/.lock || exit /b
+move target\doc site\rust || exit /b
+del site\rust\.lock || exit /b


### PR DESCRIPTION
Replaced Linux commands `mv` and `rm` with Windows `move` and `del`.
Replaced path to Windows format, as it was giving me errors too (`Parameter format not correct - "site".`)